### PR TITLE
storage/redis: key prefixing logic change

### DIFF
--- a/machine/__about__.py
+++ b/machine/__about__.py
@@ -14,7 +14,7 @@ __title__ = "aio-slack-machine"
 __description__ = "A sexy, simple, yet powerful and extendable Slack bot"
 __uri__ = "https://github.com/DandyDev/slack-machine"
 
-__version_info__ = (0, 21, 0)
+__version_info__ = (0, 21, 1)
 __version__ = ".".join(map(str, __version_info__))
 
 __author__ = "Daan Debie"

--- a/machine/storage/backends/redis.py
+++ b/machine/storage/backends/redis.py
@@ -24,6 +24,9 @@ class RedisStorage(MachineBaseStorage):
             raise NotConnectedError()
 
     def _prefix(self, key):
+        if key.startswith(self._key_prefix):
+            return key
+
         return "{}:{}".format(self._key_prefix, key)
 
     async def has(self, key):


### PR DESCRIPTION
if a key is already prefixed correctly, do not prefix it again.
this allows full keys returned by `find_keys` to be used directly
with `get`, `set`, etc.